### PR TITLE
Declare compatibility with data-values v8 and v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
         }
     },
     "require": {
-        "wikibase/data-model": "^7.3"
+        "wikibase/data-model": "^9.5.1|^8.0.0|^7.3.0"
     }
 }


### PR DESCRIPTION
This allows the installation alongside Wikibase 1.35; the changes listed in the [release notes][1] shouldn’t affect this library.

[1]: https://github.com/wmde/WikibaseDataModel/blob/master/RELEASE-NOTES.md